### PR TITLE
Remove org.json as dependency, use fastjson universally

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In project `pom.xml` file
     <dependency>
         <groupId>io.everitoken.sdk</groupId>
         <artifactId>chain-sdk</artifactId>
-        <version>1.0.0-rc2</version>
+        <version>1.0.0-rc3</version>
     </dependency>
 </dependencies>
 ```
@@ -43,7 +43,7 @@ In project `build.gradle` file
 ```gradle
 dependencies {
     // other dependencies
-    implementation 'io.everitoken.sdk:chain-sdk:1.0.0-rc1'
+    implementation 'io.everitoken.sdk:chain-sdk:1.0.0-rc3'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.everitoken.sdk</groupId>
@@ -141,11 +141,6 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>3.14.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20180813</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.everitoken.sdk</groupId>
     <artifactId>chain-sdk</artifactId>
-    <version>1.0.0-rc2</version>
+    <version>1.0.0-rc3</version>
     <packaging>jar</packaging>
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/io/everitoken/sdk/java/Api.java
+++ b/src/main/java/io/everitoken/sdk/java/Api.java
@@ -3,9 +3,10 @@ package io.everitoken.sdk.java;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.apiResource.ApiRequestConfig;
 import io.everitoken.sdk.java.apiResource.DomainDetail;

--- a/src/main/java/io/everitoken/sdk/java/EvtLink.java
+++ b/src/main/java/io/everitoken/sdk/java/EvtLink.java
@@ -13,12 +13,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.apiResource.EvtLinkStatus;
 import io.everitoken.sdk.java.dto.TokenDomain;
@@ -421,11 +422,11 @@ public class EvtLink {
 
                 isOnline = true;
 
-                if (json.getString("trx_id") != null && json.getInt("block_num") > 0) {
+                if (json.getString("trx_id") != null && json.getInteger("block_num") > 0) {
                     rst.put("pending", "false");
                     rst.put("success", "true");
                     rst.put("trx_id", json.getString("trx_id"));
-                    rst.put("block_num", Integer.toString(json.getInt("block_num")));
+                    rst.put("block_num", Integer.toString(json.getInteger("block_num")));
                     return rst;
                 }
             } catch (Exception ex) {

--- a/src/main/java/io/everitoken/sdk/java/Signer.java
+++ b/src/main/java/io/everitoken/sdk/java/Signer.java
@@ -29,7 +29,8 @@ public class Signer implements ECConstants, DSA {
     /**
      * Configuration with an alternate, possibly deterministic calculator of K.
      *
-     * @param kCalculator a K value calculator.
+     * @param kCalculator
+     *                        a K value calculator.
      */
     public Signer(DSAKCalculator kCalculator) {
         this.kCalculator = kCalculator;
@@ -83,7 +84,8 @@ public class Signer implements ECConstants, DSA {
      * with. For conventional DSA the message should be a SHA-1 hash of the message
      * of interest.
      *
-     * @param message the message that will be verified later.
+     * @param message
+     *                    the message that will be verified later.
      */
     @Override
     public BigInteger[] generateSignature(byte[] message) {
@@ -102,6 +104,7 @@ public class Signer implements ECConstants, DSA {
 
         ECMultiplier basePointMultiplier = createBasePointMultiplier();
 
+        int sLen = 0;
         // 5.3.2
         do // generate s
         {
@@ -116,10 +119,11 @@ public class Signer implements ECConstants, DSA {
                 // 5.3.3
                 r = p.getAffineXCoord().toBigInteger().mod(n);
                 rLen = r.toByteArray().length;
-            } while (r.equals(ZERO) || rLen == 33); // make sure that length of r is 32 bytes
+            } while (r.equals(ZERO) || rLen != 32); // make sure that length of r is 32 bytes
 
             s = k.modInverse(n).multiply(e.add(d.multiply(r))).mod(n);
-        } while (s.equals(ZERO));
+            sLen = s.toByteArray().length;
+        } while (s.equals(ZERO) || sLen != 32);
 
         return new BigInteger[] { r, s };
     }

--- a/src/main/java/io/everitoken/sdk/java/Utils.java
+++ b/src/main/java/io/everitoken/sdk/java/Utils.java
@@ -10,6 +10,8 @@ import java.util.Base64;
 import java.util.Hashtable;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.google.common.io.BaseEncoding;
 import com.google.zxing.BarcodeFormat;
@@ -30,8 +32,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.LocalDateTime;
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.spongycastle.crypto.digests.RIPEMD160Digest;
 
 import io.everitoken.sdk.java.exceptions.Base58CheckException;
@@ -137,8 +137,8 @@ public class Utils {
 
     public static boolean isJsonEmptyArray(String string) {
         try {
-            JSONArray array = new JSONArray(string);
-            return array.length() == 0;
+            JSONArray array = JSONArray.parseArray(string);
+            return array.size() == 0;
         } catch (JSONException ex) {
             return false;
         }

--- a/src/main/java/io/everitoken/sdk/java/abi/Abi.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/Abi.java
@@ -1,10 +1,10 @@
 package io.everitoken.sdk.java.abi;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 
-import org.json.JSONObject;
 
 public abstract class Abi implements AbiActionInterface {
     private final String name;

--- a/src/main/java/io/everitoken/sdk/java/abi/AbiToBin.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/AbiToBin.java
@@ -1,9 +1,9 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 class AbiToBin<T> {
     private final String action;

--- a/src/main/java/io/everitoken/sdk/java/abi/Action.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/Action.java
@@ -1,6 +1,6 @@
 package io.everitoken.sdk.java.abi;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 public class Action {
     private final String name;

--- a/src/main/java/io/everitoken/sdk/java/abi/GroupAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/GroupAction.java
@@ -1,8 +1,8 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
-import org.json.JSONObject;
 
 public class GroupAction extends Abi {
     @JSONField(deserialize = false, serialize = false)

--- a/src/main/java/io/everitoken/sdk/java/abi/NewDomainAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/NewDomainAction.java
@@ -2,11 +2,11 @@ package io.everitoken.sdk.java.abi;
 
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.dto.Permission;

--- a/src/main/java/io/everitoken/sdk/java/abi/NewFungibleAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/NewFungibleAction.java
@@ -1,10 +1,10 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.Asset;
 import io.everitoken.sdk.java.PublicKey;

--- a/src/main/java/io/everitoken/sdk/java/abi/NewGroupAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/NewGroupAction.java
@@ -1,10 +1,10 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 public class NewGroupAction extends GroupAction {
     @JSONField(deserialize = false, serialize = false)

--- a/src/main/java/io/everitoken/sdk/java/abi/RemoteAbiSerialisationProvider.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/RemoteAbiSerialisationProvider.java
@@ -1,7 +1,7 @@
 package io.everitoken.sdk.java.abi;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.apiResource.AbiBin;
 import io.everitoken.sdk.java.exceptions.AbiSerialisationFailureException;

--- a/src/main/java/io/everitoken/sdk/java/abi/UpdateDomainAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/UpdateDomainAction.java
@@ -1,11 +1,11 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.Permission;
 

--- a/src/main/java/io/everitoken/sdk/java/abi/UpdateFungibleAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/UpdateFungibleAction.java
@@ -1,11 +1,11 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.Symbol;
 import io.everitoken.sdk.java.dto.Permission;

--- a/src/main/java/io/everitoken/sdk/java/abi/UpdateGroupAction.java
+++ b/src/main/java/io/everitoken/sdk/java/abi/UpdateGroupAction.java
@@ -1,10 +1,10 @@
 package io.everitoken.sdk.java.abi;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 public class UpdateGroupAction extends GroupAction {
     @JSONField(deserialize = false, serialize = false)

--- a/src/main/java/io/everitoken/sdk/java/apiResource/AbiBin.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/AbiBin.java
@@ -1,6 +1,6 @@
 package io.everitoken.sdk.java.apiResource;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -14,9 +14,9 @@ public class AbiBin extends OkhttpApi {
 
     public JSONObject request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONObject json = new JSONObject(res);
+        JSONObject json = JSONObject.parseObject(res);
 
-        if (!json.has("binargs")) {
+        if (!json.containsKey("binargs")) {
             throw new ApiResponseException("Abi to bin response should have a 'binargs' field", json);
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/DomainDetail.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/DomainDetail.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.DomainDetailData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,6 @@ public class DomainDetail extends OkhttpApi {
 
     public DomainDetailData request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return DomainDetailData.of(new JSONObject(res));
+        return DomainDetailData.of(JSONObject.parseObject(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/DomainTokens.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/DomainTokens.java
@@ -3,9 +3,10 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.TokenDetailData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -24,10 +25,10 @@ public class DomainTokens extends OkhttpApi {
 
     public List<TokenDetailData> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<TokenDetailData> list = new ArrayList<>(array.length());
+        JSONArray array = JSONArray.parseArray(res);
+        List<TokenDetailData> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add(TokenDetailData.create((JSONObject) array.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/EvtLinkStatus.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/EvtLinkStatus.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -18,6 +19,6 @@ public class EvtLinkStatus extends OkhttpApi {
 
     public JSONObject request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return new JSONObject(res);
+        return JSONObject.parseObject(res);
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/FungibleAction.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/FungibleAction.java
@@ -3,9 +3,10 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.ActionData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -24,10 +25,10 @@ public class FungibleAction extends OkhttpApi {
 
     public List<ActionData> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<ActionData> list = new ArrayList<>(array.length());
+        JSONArray array = JSONArray.parseArray(res);
+        List<ActionData> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add(ActionData.create((JSONObject) array.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/FungibleBalance.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/FungibleBalance.java
@@ -3,8 +3,9 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 
 import io.everitoken.sdk.java.Asset;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -23,10 +24,10 @@ public class FungibleBalance extends OkhttpApi {
 
     public List<Asset> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<Asset> list = new ArrayList<>(array.length());
+        JSONArray array = JSONArray.parseArray(res);
+        List<Asset> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add(Asset.parseFromRawBalance((String) array.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/FungibleDetail.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/FungibleDetail.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.FungibleDetailData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,7 @@ public class FungibleDetail extends OkhttpApi {
 
     public FungibleDetailData request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return FungibleDetailData.ofRaw(new JSONObject(res));
+        return FungibleDetailData.ofRaw(JSONObject.parseObject(res));
     }
+
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/GroupDetail.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/GroupDetail.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.GroupDetailData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,6 @@ public class GroupDetail extends OkhttpApi {
 
     public GroupDetailData request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return GroupDetailData.create(new JSONObject(res));
+        return GroupDetailData.create(JSONObject.parseObject(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HeadBlockHeaderState.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HeadBlockHeaderState.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -26,6 +27,6 @@ public class HeadBlockHeaderState extends OkhttpApi {
 
     public JSONObject request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return new JSONObject(res);
+        return  JSONObject.parseObject(res);
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HistoryAction.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HistoryAction.java
@@ -3,9 +3,10 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.ActionData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -24,10 +25,10 @@ public class HistoryAction extends OkhttpApi {
 
     public List<ActionData> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<ActionData> list = new ArrayList<>(array.length());
+        JSONArray array = JSONArray.parseArray(res);
+        List<ActionData> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add(ActionData.create((JSONObject) array.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HistoryDomain.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HistoryDomain.java
@@ -3,8 +3,9 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 
 import io.everitoken.sdk.java.dto.NameableResource;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -23,10 +24,10 @@ public class HistoryDomain extends OkhttpApi {
 
     public List<NameableResource> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<NameableResource> list = new ArrayList<>(array.length());
+        JSONArray array =  JSONArray.parseArray(res);
+        List<NameableResource> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add(NameableResource.create((String) array.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HistoryFungible.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HistoryFungible.java
@@ -3,8 +3,9 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 
 import io.everitoken.sdk.java.dto.FungibleCreated;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -23,10 +24,10 @@ public class HistoryFungible extends OkhttpApi {
 
     public FungibleCreated request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<Integer> ids = new ArrayList<>(array.length());
+        JSONArray array =  JSONArray.parseArray(res);
+        List<Integer> ids = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             ids.add((int) array.get(i));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HistoryGroup.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HistoryGroup.java
@@ -3,8 +3,9 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 
 import io.everitoken.sdk.java.dto.NameableResource;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -23,10 +24,10 @@ public class HistoryGroup extends OkhttpApi {
 
     public List<NameableResource> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONArray(res);
-        List<NameableResource> list = new ArrayList<>(array.length());
+        JSONArray array =  JSONArray.parseArray(res);
+        List<NameableResource> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add(NameableResource.create((String) array.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HistoryToken.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HistoryToken.java
@@ -1,12 +1,13 @@
 package io.everitoken.sdk.java.apiResource;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.Utils;
 import io.everitoken.sdk.java.dto.TokenDomain;
@@ -31,16 +32,16 @@ public class HistoryToken extends OkhttpApi {
             return new ArrayList<>();
         }
 
-        JSONObject payload = new JSONObject(res);
+        JSONObject payload = JSONObject.parseObject(res);
+        System.out.println(payload);
 
         List<TokenDomain> tokens = new ArrayList<>();
 
-        Iterator<String> domains = payload.keys();
+        Set<String> domains = payload.keySet();
 
-        while (domains.hasNext()) {
-            String domainName = domains.next();
-            JSONArray tokensInDomain = payload.getJSONArray(domainName);
-            tokensInDomain.forEach(tokenInDomain -> tokens.add(new TokenDomain((String) tokenInDomain, domainName)));
+        for (String key : domains) {
+            JSONArray tokensInDomain = payload.getJSONArray(key);
+            tokensInDomain.forEach(tokenInDomain -> tokens.add(new TokenDomain((String) tokenInDomain, key)));
         }
 
         return tokens;

--- a/src/main/java/io/everitoken/sdk/java/apiResource/HistoryTransactionDetail.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/HistoryTransactionDetail.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.TransactionDetail;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -24,6 +25,6 @@ public class HistoryTransactionDetail extends OkhttpApi {
 
     public TransactionDetail request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return TransactionDetail.create(new JSONObject(res));
+        return TransactionDetail.create(JSONObject.parseObject(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/OkhttpApi.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/OkhttpApi.java
@@ -56,7 +56,7 @@ class OkhttpApi {
     protected Request buildRequest(RequestParams requestParams) {
         RequestBody body = RequestBody.create(JSON_TYPE, requestParams.getApiParams().asBody());
 
-        return new Request.Builder().header(CUSTOM_REQUEST_HEADER, "1.0.0-rc2")
+        return new Request.Builder().header(CUSTOM_REQUEST_HEADER, "1.0.0-rc3")
                 .url(getUrl(requestParams.getNetParams())).post(body).build();
     }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/OkhttpApi.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/OkhttpApi.java
@@ -3,12 +3,13 @@ package io.everitoken.sdk.java.apiResource;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.NetParams;
@@ -90,7 +91,7 @@ class OkhttpApi {
         boolean isArray = false;
 
         try {
-            new JSONArray(body);
+            JSONArray.parseArray(body);
             isArray = true;
         } catch (JSONException ex) {
         }
@@ -99,10 +100,9 @@ class OkhttpApi {
             return;
         }
 
-        JSONObject res = new JSONObject();
-        res = new JSONObject(body);
+        JSONObject res = JSONObject.parseObject(body);
 
-        if (res.has("error")) {
+        if (res.containsKey("error")) {
             throw new ApiResponseException(String.format("Response Error for '%s'", uri), res);
         }
     }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/RequiredSuspendedKeys.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/RequiredSuspendedKeys.java
@@ -1,8 +1,9 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -20,6 +21,6 @@ public class RequiredSuspendedKeys extends OkhttpApi {
 
     public JSONArray request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return new JSONObject(res).getJSONArray("required_keys");
+        return JSONObject.parseObject(res).getJSONArray("required_keys");
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/SignableDigest.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/SignableDigest.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.Utils;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,6 @@ public class SignableDigest extends OkhttpApi {
 
     public byte[] request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return Utils.HEX.decode(new JSONObject(res).getString("digest"));
+        return Utils.HEX.decode(JSONObject.parseObject(res).getString("digest"));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/SigningRequiredKeys.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/SigningRequiredKeys.java
@@ -3,9 +3,10 @@ package io.everitoken.sdk.java.apiResource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -23,10 +24,10 @@ public class SigningRequiredKeys extends OkhttpApi {
 
     public List<String> request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        JSONArray array = new JSONObject(res).getJSONArray("required_keys");
-        List<String> list = new ArrayList<>(array.length());
+        JSONArray array = JSONObject.parseObject(res).getJSONArray("required_keys");
+        List<String> list = new ArrayList<>(array.size());
 
-        for (int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.size(); i++) {
             list.add((String) array.get(i));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/apiResource/TokenDetail.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/TokenDetail.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.TokenDetailData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,6 @@ public class TokenDetail extends OkhttpApi {
 
     public TokenDetailData request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return TokenDetailData.create(new JSONObject(res));
+        return TokenDetailData.create(JSONObject.parseObject(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/TransactionCommit.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/TransactionCommit.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.TransactionData;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,6 @@ public class TransactionCommit extends OkhttpApi {
 
     public TransactionData request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return TransactionData.ofRaw(new JSONObject(res));
+        return TransactionData.ofRaw(JSONObject.parseObject(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/TransactionDetailsOfPublicKeys.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/TransactionDetailsOfPublicKeys.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONArray;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -19,6 +20,6 @@ public class TransactionDetailsOfPublicKeys extends OkhttpApi {
 
     public JSONArray request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return new JSONArray(res);
+        return JSONArray.parseArray(res);
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/TransactionEstimatedCharge.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/TransactionEstimatedCharge.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.dto.Charge;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
@@ -20,6 +21,6 @@ public class TransactionEstimatedCharge extends OkhttpApi {
 
     public Charge request(RequestParams requestParams) throws ApiResponseException {
         String res = super.makeRequest(requestParams);
-        return Charge.ofRaw(new JSONObject(res));
+        return Charge.ofRaw(JSONObject.parseObject(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/apiResource/TransactionIds.java
+++ b/src/main/java/io/everitoken/sdk/java/apiResource/TransactionIds.java
@@ -1,7 +1,8 @@
 package io.everitoken.sdk.java.apiResource;
 
+import com.alibaba.fastjson.JSONArray;
+
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.RequestParams;
@@ -18,6 +19,6 @@ public class TransactionIds extends OkhttpApi {
     }
 
     public JSONArray request(RequestParams requestParams) throws ApiResponseException {
-        return new JSONArray(super.makeRequest(requestParams));
+        return JSONArray.parseArray(super.makeRequest(requestParams));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/dto/ActionData.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/ActionData.java
@@ -2,12 +2,12 @@ package io.everitoken.sdk.java.dto;
 
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
-import org.json.JSONObject;
 
 public class ActionData implements Transactable {
     private final String trxId;

--- a/src/main/java/io/everitoken/sdk/java/dto/AuthorizerWeight.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/AuthorizerWeight.java
@@ -3,10 +3,10 @@ package io.everitoken.sdk.java.dto;
 import java.util.Objects;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 
@@ -23,7 +23,7 @@ public class AuthorizerWeight {
     @Contract("_ -> new")
     public static AuthorizerWeight ofRaw(@NotNull JSONObject raw) {
         Objects.requireNonNull(raw);
-        return new AuthorizerWeight(raw.getString("ref"), raw.getInt("weight"));
+        return new AuthorizerWeight(raw.getString("ref"), raw.getInteger("weight"));
     }
 
     @NotNull

--- a/src/main/java/io/everitoken/sdk/java/dto/Charge.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/Charge.java
@@ -2,9 +2,10 @@ package io.everitoken.sdk.java.dto;
 
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 public class Charge {
     private final int charge;
@@ -23,7 +24,7 @@ public class Charge {
     @NotNull
     public static Charge ofRaw(@NotNull JSONObject raw) {
         Objects.requireNonNull(raw);
-        int charge = raw.getInt("charge");
+        int charge = raw.getInteger("charge");
         return new Charge(charge);
     }
 

--- a/src/main/java/io/everitoken/sdk/java/dto/DomainDetailData.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/DomainDetailData.java
@@ -2,14 +2,14 @@ package io.everitoken.sdk.java.dto;
 
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.abi.NewDomainAction;
 

--- a/src/main/java/io/everitoken/sdk/java/dto/FungibleDetailData.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/FungibleDetailData.java
@@ -2,13 +2,13 @@ package io.everitoken.sdk.java.dto;
 
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.Address;
 import io.everitoken.sdk.java.Asset;

--- a/src/main/java/io/everitoken/sdk/java/dto/GroupDetailData.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/GroupDetailData.java
@@ -2,11 +2,12 @@ package io.everitoken.sdk.java.dto;
 
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.exceptions.InvalidPublicKeyException;

--- a/src/main/java/io/everitoken/sdk/java/dto/Meta.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/Meta.java
@@ -1,6 +1,6 @@
 package io.everitoken.sdk.java.dto;
 
-import org.json.JSONArray;
+import com.alibaba.fastjson.JSONArray;
 
 public interface Meta {
     // TODO implement according to abi reference

--- a/src/main/java/io/everitoken/sdk/java/dto/Permission.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/Permission.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 public class Permission implements Namable {
     private final String name;
@@ -25,11 +25,11 @@ public class Permission implements Namable {
     public static Permission ofRaw(@NotNull JSONObject raw) {
         Objects.requireNonNull(raw);
         String name = raw.getString("name");
-        int threshold = raw.getInt("threshold");
+        int threshold = raw.getInteger("threshold");
         List<AuthorizerWeight> authorizers = new ArrayList<>();
         JSONArray authorizersArray = raw.getJSONArray("authorizers");
 
-        for (int i = 0; i < authorizersArray.length(); i++) {
+        for (int i = 0; i < authorizersArray.size(); i++) {
             authorizers.add(AuthorizerWeight.ofRaw((JSONObject) authorizersArray.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/dto/TokenDetailData.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/TokenDetailData.java
@@ -4,11 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.exceptions.InvalidPublicKeyException;
@@ -26,7 +27,7 @@ public class TokenDetailData implements Meta {
 
         JSONArray owner = raw.getJSONArray("owner");
 
-        for (int i = 0; i < owner.length(); i++) {
+        for (int i = 0; i < owner.size(); i++) {
             try {
                 PublicKey publicKey = PublicKey.of((String) owner.get(i));
                 this.owner.add(publicKey);

--- a/src/main/java/io/everitoken/sdk/java/dto/Transaction.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/Transaction.java
@@ -4,9 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
-
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.abi.Action;
 
@@ -22,7 +21,7 @@ public class Transaction {
     public Transaction(final List<String> actions, final String expiration, final int refBlockNumber,
             final long refBlockPrefix, final int maxCharge, final String payer) {
 
-        this.actions = actions.stream().map(JSONObject::new).map(Action::ofRaw).collect(Collectors.toList());
+        this.actions = actions.stream().map(JSONObject::parseObject).map(Action::ofRaw).collect(Collectors.toList());
         this.expiration = expiration;
         this.refBlockNumber = refBlockNumber;
         this.refBlockPrefix = refBlockPrefix;

--- a/src/main/java/io/everitoken/sdk/java/dto/TransactionData.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/TransactionData.java
@@ -1,10 +1,10 @@
 package io.everitoken.sdk.java.dto;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 public class TransactionData implements Transactable {
     private final String trxId;

--- a/src/main/java/io/everitoken/sdk/java/dto/TransactionDetail.java
+++ b/src/main/java/io/everitoken/sdk/java/dto/TransactionDetail.java
@@ -4,13 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import io.everitoken.sdk.java.Signature;
 
@@ -24,13 +24,13 @@ public class TransactionDetail {
     private final String blockId;
 
     private TransactionDetail(@NotNull JSONObject raw) throws JSONException {
-        blockNum = raw.getInt("block_num");
+        blockNum = raw.getInteger("block_num");
         packedTrx = raw.getString("packed_trx");
         id = raw.getString("id");
         compression = raw.getString("compression");
         JSONArray signaturesArray = raw.getJSONArray("signatures");
 
-        for (int i = 0; i < signaturesArray.length(); i++) {
+        for (int i = 0; i < signaturesArray.size(); i++) {
             signatures.add(Signature.of((String) signaturesArray.get(i)));
         }
 

--- a/src/main/java/io/everitoken/sdk/java/example/ApiExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/ApiExample.java
@@ -22,9 +22,9 @@ import io.everitoken.sdk.java.dto.TokenDomain;
 import io.everitoken.sdk.java.dto.TransactionDetail;
 import io.everitoken.sdk.java.exceptions.ApiResponseException;
 import io.everitoken.sdk.java.param.ActionQueryParams;
+import io.everitoken.sdk.java.param.FungibleActionParams;
 import io.everitoken.sdk.java.param.MainNetNetParams;
 import io.everitoken.sdk.java.param.NetParams;
-import io.everitoken.sdk.java.param.NetParams.NET;
 import io.everitoken.sdk.java.param.PublicKeysParams;
 import io.everitoken.sdk.java.param.TestNetNetParams;
 import io.everitoken.sdk.java.param.TransactionDetailParams;
@@ -35,14 +35,20 @@ public class ApiExample {
             // replace this with method you want to test
             // getTransactionDetailById("93e0aa6bed4b2b768ce4617cc2cb66319aaef87bdc413cbb7148cc4690bc799f");
             // getGroupDetail();
-            getOwnedTokens();
-            // getTransactionsDetailOfPublicKeys(); // test
+            // getOwnedTokens();
+            // testDomainTokens();
+            // getFungibleBalance(); // test
+            // getActions();
+            // getFungibleSymbolDetail();
+            // getFungibleActionsByAddress();
+            getTransactionsDetailOfPublicKeys();
+            // getManagedGroups();
             // getCreatedDomain();
             // getCreatedFungibles();
 
             // NetParams netParams = new TestNetNetParams();
-            // JSONObject state = new Api(netParams).getHeadBlockHeaderState();
-            // System.out.println(state.toString());
+            // NodeInfo state = new Api(netParams).getInfo();
+            // System.out.println(JSON.toJSONString(state));
         } catch (ApiResponseException ex) {
             System.out.println(ex.getRaw());
         }
@@ -50,7 +56,7 @@ public class ApiExample {
 
     static void testDomainTokens() throws ApiResponseException {
         NetParams netParams = new TestNetNetParams();
-        List<TokenDetailData> domainTokens = new Api(netParams).getDomainTokens("test1122", 10, 0);
+        List<TokenDetailData> domainTokens = new Api(netParams).getDomainTokens("test1123", 10, 0);
         domainTokens.stream().forEach(tokenDetailData -> {
             System.out.println(tokenDetailData.getName());
         });
@@ -100,7 +106,7 @@ public class ApiExample {
 
     static void getActions() throws ApiResponseException {
         NetParams netParams = new TestNetNetParams();
-        ActionQueryParams actionParams = new ActionQueryParams("testdomainfei1", null,
+        ActionQueryParams actionParams = new ActionQueryParams("test1123", null,
                 new String[] { "issuetoken", "transfer" });
 
         List<ActionData> res = new Api(netParams).getActions(actionParams);
@@ -128,10 +134,10 @@ public class ApiExample {
     }
 
     static void getFungibleBalance() throws ApiResponseException {
-        NetParams netParams = new MainNetNetParams(NET.MAINNET1);
+        NetParams netParams = new TestNetNetParams();
         List<Asset> res = new Api(netParams)
                 .getFungibleBalance(Address.of("EVT8aNw4NTvjBL1XR6hgy4zcA9jzh1JLjMuAw85mSbW68vYzw2f9H"));
-        res.forEach(balance -> System.out.println(balance.toString()));
+        System.out.println(JSON.toJSONString(res));
     }
 
     static void getTransactionDetailById(String trxId) throws ApiResponseException {
@@ -145,6 +151,7 @@ public class ApiExample {
     static void getFungibleSymbolDetail() throws ApiResponseException {
         NetParams netParams = new TestNetNetParams();
         FungibleDetailData res = new Api(netParams).getFungibleSymbolDetail(1);
+        System.out.println(JSON.toJSONString(res));
         System.out.println(res.getCreator());
     }
 
@@ -153,5 +160,14 @@ public class ApiExample {
         JSONArray res = new Api(netParams).getTransactionsDetailOfPublicKeys(
                 Arrays.asList(PublicKey.of("EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND")), 0, 2, "asc");
         System.out.println(res);
+    }
+
+    static void getFungibleActionsByAddress() throws ApiResponseException {
+        NetParams netParams = new TestNetNetParams();
+        FungibleActionParams params = FungibleActionParams.of("EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND",
+                "20");
+
+        List<ActionData> res = new Api(netParams).getFungibleActionsByAddress(params);
+        System.out.println(JSON.toJSONString(res));
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/example/ApiExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/ApiExample.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
 
 import io.everitoken.sdk.java.Address;
 import io.everitoken.sdk.java.Api;
@@ -32,11 +33,13 @@ public class ApiExample {
     public static void main(String[] args) {
         try {
             // replace this with method you want to test
-            // getTransactionDetailById("93e0aa6bed4b2b768ce461jcc2cb66319aaef87bdc413cbb7148cc4690bc799f");
+            // getTransactionDetailById("93e0aa6bed4b2b768ce4617cc2cb66319aaef87bdc413cbb7148cc4690bc799f");
             // getGroupDetail();
-            getTransactionsDetailOfPublicKeys(); // test
+            getOwnedTokens();
+            // getTransactionsDetailOfPublicKeys(); // test
             // getCreatedDomain();
             // getCreatedFungibles();
+
             // NetParams netParams = new TestNetNetParams();
             // JSONObject state = new Api(netParams).getHeadBlockHeaderState();
             // System.out.println(state.toString());
@@ -147,8 +150,8 @@ public class ApiExample {
 
     static void getTransactionsDetailOfPublicKeys() throws ApiResponseException {
         NetParams netParams = new TestNetNetParams();
-        org.json.JSONArray res = new Api(netParams).getTransactionsDetailOfPublicKeys(
-                Arrays.asList(PublicKey.of("EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND")), 1, 1, "asc");
+        JSONArray res = new Api(netParams).getTransactionsDetailOfPublicKeys(
+                Arrays.asList(PublicKey.of("EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND")), 0, 2, "asc");
         System.out.println(res);
     }
 }

--- a/src/main/java/io/everitoken/sdk/java/example/DestroyTokenExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/DestroyTokenExample.java
@@ -16,7 +16,7 @@ public class DestroyTokenExample {
     public static void main(String[] args) {
         NetParams netParam = new TestNetNetParams();
 
-        DestroyTokenAction destroyTokenAction = DestroyTokenAction.of("test1123", "t3");
+        DestroyTokenAction destroyTokenAction = DestroyTokenAction.of("test1123", "t6");
 
         try {
             TransactionService transactionService = TransactionService.of(netParam);

--- a/src/main/java/io/everitoken/sdk/java/example/IssueTokenExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/IssueTokenExample.java
@@ -17,7 +17,7 @@ import io.everitoken.sdk.java.service.TransactionService;
 public class IssueTokenExample {
     public static void main(String[] args) {
         NetParams netParam = new TestNetNetParams();
-        IssueTokenAction issueTokenAction = IssueTokenAction.of("test1123", Arrays.asList("t1", "t3"),
+        IssueTokenAction issueTokenAction = IssueTokenAction.of("test1123", Arrays.asList("t5", "t6"),
                 Collections.singletonList(Address.of("EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND")));
 
         try {

--- a/src/main/java/io/everitoken/sdk/java/example/NewDomainExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/NewDomainExample.java
@@ -2,7 +2,7 @@ package io.everitoken.sdk.java.example;
 
 import java.util.Arrays;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.abi.NewDomainAction;
@@ -26,7 +26,7 @@ public class NewDomainExample {
                 + "\"authorizers\":[{\"ref\":\"[A]"
                 + " EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":1}]}}";
 
-        final JSONObject json = new JSONObject(data);
+        final JSONObject json = JSONObject.parseObject(data);
         final NewDomainAction newDomainAction = NewDomainAction.ofRaw(json.getString("name"), json.getString("creator"),
                 json.getJSONObject("issue"), json.getJSONObject("transfer"), json.getJSONObject("manage"));
 

--- a/src/main/java/io/everitoken/sdk/java/example/NewFungibleExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/NewFungibleExample.java
@@ -2,7 +2,7 @@ package io.everitoken.sdk.java.example;
 
 import java.util.Arrays;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.Symbol;
@@ -21,9 +21,9 @@ public class NewFungibleExample {
 
         NewFungibleAction newFungibleAction = NewFungibleAction.of(Symbol.of(20, 5), ".JAVA",
                 "EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND",
-                new JSONObject("{\"name\":\"issue\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] "
+                JSONObject.parseObject("{\"name\":\"issue\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] "
                         + "EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":" + "1}]}"),
-                new JSONObject("{\"name\":\"manage\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] "
+                JSONObject.parseObject("{\"name\":\"manage\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] "
                         + "EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":" + "1}]}"),
                 "20000.00000 S#20");
         try {

--- a/src/main/java/io/everitoken/sdk/java/example/NewGroupExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/NewGroupExample.java
@@ -2,7 +2,7 @@ package io.everitoken.sdk.java.example;
 
 import java.util.Arrays;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.abi.NewGroupAction;
@@ -26,7 +26,7 @@ public class NewGroupExample {
                 + "\"weight\":3,\"nodes\":[{\"key\":\"EVT6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\","
                 + "\"weight\":1},{\"key\":\"EVT8MGU4aKiVzqMtWi9zLpu8KuTHZWjQQrX475ycSxEkLd6aBpraX\",\"weight\":1}]}]}}";
 
-        final JSONObject json = new JSONObject(data);
+        final JSONObject json = JSONObject.parseObject(data);
         final NewGroupAction newGroupAction = NewGroupAction.ofRaw("feitestgroup2", json);
 
         try {

--- a/src/main/java/io/everitoken/sdk/java/example/UpdateDomainExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/UpdateDomainExample.java
@@ -2,7 +2,7 @@ package io.everitoken.sdk.java.example;
 
 import java.util.Arrays;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.abi.UpdateDomainAction;
@@ -21,7 +21,7 @@ public class UpdateDomainExample {
                 + "EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":1},{\"ref\":\"[A] "
                 + "EVT5cd4a3RyaVoubc4w3j3Z3YvCJgtKZPRdJHDdk7wVsMbc3yEH5U\",\"weight\":1}]},\"name\":\"test1123\"}";
 
-        final JSONObject json = new JSONObject(data);
+        final JSONObject json = JSONObject.parseObject(data);
         final UpdateDomainAction updateDomainAction = UpdateDomainAction.ofRaw(json.getString("name"), null, null,
                 json.getJSONObject("manage"));
 

--- a/src/main/java/io/everitoken/sdk/java/example/UpdateFungibleExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/UpdateFungibleExample.java
@@ -2,7 +2,7 @@ package io.everitoken.sdk.java.example;
 
 import java.util.Arrays;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.Symbol;
@@ -20,7 +20,7 @@ public class UpdateFungibleExample {
         NetParams netParam = new TestNetNetParams();
 
         UpdateFungibleAction updateFungibleAction = UpdateFungibleAction.of(Symbol.of(20, 5),
-                new JSONObject("{\"name\":\"issue\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] "
+                JSONObject.parseObject("{\"name\":\"issue\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] "
                         + "EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":" + "1}, {\"ref\":\"[A] "
                         + "EVT8aNw4NTvjBL1XR6hgy4zcA9jzh1JLjMuAw85mSbW68vYzw2f9H\",\"weight\":" + "1}]}"),
                 null);

--- a/src/main/java/io/everitoken/sdk/java/example/UpdateGroupExample.java
+++ b/src/main/java/io/everitoken/sdk/java/example/UpdateGroupExample.java
@@ -2,7 +2,7 @@ package io.everitoken.sdk.java.example;
 
 import java.util.Arrays;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 import io.everitoken.sdk.java.PublicKey;
 import io.everitoken.sdk.java.abi.UpdateGroupAction;
@@ -28,7 +28,7 @@ public class UpdateGroupExample {
                 + "        \"key\": \"EVT8MGU4aKiVzqMtWi9zLpu8KuTHZWjQQrX475ycSxEkLd6aBpraX\",\n"
                 + "        \"weight\": 3\n" + "      }\n" + "    ]\n" + "  }\n" + "}";
 
-        final JSONObject json = new JSONObject(data);
+        final JSONObject json = JSONObject.parseObject(data);
         final UpdateGroupAction updateGroupAction = UpdateGroupAction.ofRaw("feitestgroup2", json);
 
         try {

--- a/src/main/java/io/everitoken/sdk/java/exceptions/ApiResponseException.java
+++ b/src/main/java/io/everitoken/sdk/java/exceptions/ApiResponseException.java
@@ -1,6 +1,6 @@
 package io.everitoken.sdk.java.exceptions;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 public class ApiResponseException extends Exception implements EvtException {
     private JSONObject raw;

--- a/src/main/java/io/everitoken/sdk/java/param/FungibleActionParams.java
+++ b/src/main/java/io/everitoken/sdk/java/param/FungibleActionParams.java
@@ -16,8 +16,12 @@ public class FungibleActionParams implements ApiParams, Paginatable {
         this.take = take;
     }
 
-    FungibleActionParams(String address, String symbolId) {
-        this(address, symbolId, 0, 10);
+    public static FungibleActionParams of(String address, String symbolId) {
+        return new FungibleActionParams(address, symbolId, 0, 10);
+    }
+
+    public static FungibleActionParams of(String address, String symbolId, int skip, int take) {
+        return new FungibleActionParams(address, symbolId, skip, take);
     }
 
     @Override

--- a/src/test/java/io/everitoken/sdk/java/SignatureTest.java
+++ b/src/test/java/io/everitoken/sdk/java/SignatureTest.java
@@ -90,7 +90,7 @@ class SignatureTest {
             String message = "helloworld";
             PrivateKey key = PrivateKey.of("5JV1kctxPzU3BdRENgRyDcUWQSqqzeckzjKXJWSkBoxXmXUCqKB");
             Signature sig = Signature.sign((message.getBytes()), key);
-            assertEquals(1, sig.getRecId());
+            assertEquals(0, sig.getRecId());
         });
     }
 
@@ -138,5 +138,16 @@ class SignatureTest {
                     Utils.HEX.encode(signature.getS().toByteArray()));
             assertEquals(1, signature.getRecId());
         });
+    }
+
+    @Test
+    @DisplayName("Edge case")
+    void testEdgeCase() {
+        String target = "SIG_K1_KiQbpiJSi9f3MUDP9xnkHF6m3Fpj7um7kvXAvmjEqMuKctB1pupPyxHPNNZQ3MGGnjqpXP69rSoL8auvoZC7rQ6HtGU8CQ";
+        PrivateKey key = PrivateKey.of("5J7KoMB4P9cQCD2P529Zmscz3sH3oNVRQ1ZnHXVk68Y15uByTNe");
+
+        Signature sig = Signature.sign(String.valueOf(45).getBytes(), key);
+
+        assertEquals(target, sig.toString());
     }
 }

--- a/src/test/java/io/everitoken/sdk/java/abi/NewDomainActionTest.java
+++ b/src/test/java/io/everitoken/sdk/java/abi/NewDomainActionTest.java
@@ -1,41 +1,37 @@
 package io.everitoken.sdk.java.abi;
 
-import io.everitoken.sdk.java.param.MainNetNetParams;
-import io.everitoken.sdk.java.param.NetParams;
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.everitoken.sdk.java.param.MainNetNetParams;
+import io.everitoken.sdk.java.param.NetParams;
+
 class NewDomainActionTest {
-    private final String data = "{\"name\":\"test111\"," +
-            "\"creator\":\"EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"issue\":{\"name\":\"issue\"," +
-            "\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\"," +
-            "\"weight\":1}]},\"transfer\":{\"name\":\"transfer\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[G] " +
-            ".OWNER\",\"weight\":1}]},\"manage\":{\"name\":\"manage\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A]" +
-            " EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":1}]}}";
-    private final String dataSerialisedByAdi =
-            "7d90f70dc30000000002c8f031561c4758c9551cff47246f2c347189fe684c04da35cf88e813f810e3c2000000008052e74c01000" +
-                    "00001010002c8f031561c4758c9551cff47246f2c347189fe684c04da35cf88e813f810e3c20100000000b298e982a40100" +
-                    "000001000001000000000094135c680100000001010002c8f031561c4758c9551cff47246f2c347189fe684c04da35cf" +
-                    "88e813f810e3c20100";
+    private final String data = "{\"name\":\"test111\","
+            + "\"creator\":\"EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"issue\":{\"name\":\"issue\","
+            + "\"threshold\":1,\"authorizers\":[{\"ref\":\"[A] EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\","
+            + "\"weight\":1}]},\"transfer\":{\"name\":\"transfer\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[G] "
+            + ".OWNER\",\"weight\":1}]},\"manage\":{\"name\":\"manage\",\"threshold\":1,\"authorizers\":[{\"ref\":\"[A]"
+            + " EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND\",\"weight\":1}]}}";
+    private final String dataSerialisedByAdi = "7d90f70dc30000000002c8f031561c4758c9551cff47246f2c347189fe684c04da35cf88e813f810e3c2000000008052e74c01000"
+            + "00001010002c8f031561c4758c9551cff47246f2c347189fe684c04da35cf88e813f810e3c20100000000b298e982a40100"
+            + "000001000001000000000094135c680100000001010002c8f031561c4758c9551cff47246f2c347189fe684c04da35cf"
+            + "88e813f810e3c20100";
 
     @Test
     @DisplayName("Able to serialize via api")
     void serialize() {
         Assertions.assertDoesNotThrow(() -> {
-            JSONObject json = new JSONObject(data);
-            NewDomainAction newDomainAction = NewDomainAction.ofRaw(
-                    json.getString("name"),
-                    json.getString("creator"),
-                    json.getJSONObject("issue"),
-                    json.getJSONObject("transfer"),
-                    json.getJSONObject("manage")
-            );
+            JSONObject json = JSONObject.parseObject(data);
+            NewDomainAction newDomainAction = NewDomainAction.ofRaw(json.getString("name"), json.getString("creator"),
+                    json.getJSONObject("issue"), json.getJSONObject("transfer"), json.getJSONObject("manage"));
 
             NetParams netParams = new MainNetNetParams(NetParams.NET.MAINNET1);
             RemoteAbiSerialisationProvider provider = new RemoteAbiSerialisationProvider(netParams);
-            JSONObject res = new JSONObject(newDomainAction.serialize(provider));
+            JSONObject res = JSONObject.parseObject(newDomainAction.serialize(provider));
             Assertions.assertEquals(dataSerialisedByAdi, res.get("data"));
         });
     }

--- a/src/test/java/io/everitoken/sdk/java/abi/RemoteAbiSerialisationProviderInterfaceTest.java
+++ b/src/test/java/io/everitoken/sdk/java/abi/RemoteAbiSerialisationProviderInterfaceTest.java
@@ -1,6 +1,7 @@
 package io.everitoken.sdk.java.abi;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -40,7 +41,7 @@ class RemoteAbiSerialisationProviderInterfaceTest {
         Assertions.assertDoesNotThrow(() -> {
             NetParams netParams = new TestNetNetParams();
             RemoteAbiSerialisationProvider provider = new RemoteAbiSerialisationProvider(netParams);
-            new JSONObject(provider.serialize(data));
+            JSONObject.parseObject(provider.serialize(data));
         });
     }
 
@@ -50,7 +51,7 @@ class RemoteAbiSerialisationProviderInterfaceTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             NetParams netParams = new TestNetNetParams();
             RemoteAbiSerialisationProvider provider = new RemoteAbiSerialisationProvider(netParams);
-            new JSONObject(provider.serialize(""));
+            JSONObject.parseObject(provider.serialize(""));
         });
     }
 
@@ -60,7 +61,7 @@ class RemoteAbiSerialisationProviderInterfaceTest {
         Throwable throwable = Assertions.assertThrows(AbiSerialisationFailureException.class, () -> {
             NetParams netParams = new TestNetNetParams();
             RemoteAbiSerialisationProvider provider = new RemoteAbiSerialisationProvider(netParams);
-            new JSONObject(provider.serialize("{\"action\":\"newgroup\", \"args\": {}}\""));
+            JSONObject.parseObject(provider.serialize("{\"action\":\"newgroup\", \"args\": {}}\""));
         });
         Assertions.assertTrue(throwable.getMessage().contains("Failed to serialize Abi"));
     }

--- a/src/test/java/io/everitoken/sdk/java/apiResource/SigningRequiredKeysTest.java
+++ b/src/test/java/io/everitoken/sdk/java/apiResource/SigningRequiredKeysTest.java
@@ -2,7 +2,8 @@ package io.everitoken.sdk.java.apiResource;
 
 import java.util.List;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -26,7 +27,7 @@ class SigningRequiredKeysTest {
 
             List<String> res = signingRequiredKeys.request(RequestParams.of(netParams, () -> {
                 JSONObject json = new JSONObject();
-                json.put("transaction", new JSONObject(transaction));
+                json.put("transaction", JSONObject.parseObject(transaction));
                 json.put("available_keys", publicKeys);
                 return json.toString();
             }));

--- a/src/test/java/io/everitoken/sdk/java/apiResource/TransactionEstimatedChargeTest.java
+++ b/src/test/java/io/everitoken/sdk/java/apiResource/TransactionEstimatedChargeTest.java
@@ -1,6 +1,7 @@
 package io.everitoken.sdk.java.apiResource;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -23,7 +24,7 @@ class TransactionEstimatedChargeTest {
 
             Charge res = transactionEstimatedCharge.request(RequestParams.of(netParams, () -> {
                 JSONObject json = new JSONObject();
-                json.put("transaction", new JSONObject(transaction));
+                json.put("transaction", JSONObject.parseObject(transaction));
                 json.put("sign_num", 1);
                 return json.toString();
             }));

--- a/src/test/java/io/everitoken/sdk/java/dto/ActionDataTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/ActionDataTest.java
@@ -1,7 +1,7 @@
 package io.everitoken.sdk.java.dto;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +11,7 @@ class ActionDataTest {
     @Test
     @DisplayName("Should throw correct exception")
     void throwCorrectException() {
-        Assertions.assertThrows(JSONException.class, () -> ActionData.create(new JSONObject()));
+        Assertions.assertThrows(NullPointerException.class, () -> ActionData.create(JSONObject.parseObject("")));
     }
 
 }

--- a/src/test/java/io/everitoken/sdk/java/dto/AuthorizerWeightTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/AuthorizerWeightTest.java
@@ -1,8 +1,8 @@
 package io.everitoken.sdk.java.dto;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 
-import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,16 +14,16 @@ class AuthorizerWeightTest {
     @DisplayName("JSON serialize")
     void toJSONString() {
         AuthorizerWeight authorizerWeight = AuthorizerWeight.createOwner(2);
-        JSONObject json = new JSONObject(JSON.toJSONString(authorizerWeight));
+        JSONObject json = JSONObject.parseObject(JSON.toJSONString(authorizerWeight));
         Assertions.assertEquals("[G] .OWNER", json.getString("ref"));
-        Assertions.assertEquals(2, json.getInt("weight"));
+        Assertions.assertEquals(2, (int) json.getInteger("weight"));
 
         PublicKey key = PublicKey.of("EVT76uLwUD5t6fkob9Rbc9UxHgdTVshNceyv2hmppw4d82j2zYRpa");
         AuthorizerWeight authorizerWeight1 = AuthorizerWeight.createAccount(key, 1);
-        JSONObject json1 = new JSONObject(JSON.toJSONString(authorizerWeight1));
+        JSONObject json1 = JSONObject.parseObject(JSON.toJSONString(authorizerWeight1));
         Assertions.assertEquals(json1.getString("ref"),
                 String.format("%s %s", "[A]", "EVT76uLwUD5t6fkob9Rbc9UxHgdTVshNceyv2hmppw4d82j2zYRpa"));
-        Assertions.assertEquals(1, json1.getInt("weight"));
+        Assertions.assertEquals(1, (int) json1.getInteger("weight"));
     }
 
     @Test

--- a/src/test/java/io/everitoken/sdk/java/dto/FungibleDetailDataTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/FungibleDetailDataTest.java
@@ -1,6 +1,7 @@
 package io.everitoken.sdk.java.dto;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class FungibleDetailDataTest {
     @DisplayName("Deserialize should be correct")
     void deserialize() {
         Assertions.assertDoesNotThrow(() -> {
-            FungibleDetailData.ofRaw(new JSONObject(raw));
+            FungibleDetailData.ofRaw(JSONObject.parseObject(raw));
         });
     }
 }

--- a/src/test/java/io/everitoken/sdk/java/dto/GroupDetailDataTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/GroupDetailDataTest.java
@@ -1,8 +1,9 @@
 package io.everitoken.sdk.java.dto;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,7 @@ class GroupDetailDataTest {
     @DisplayName("Throw JSON exception if can't parse json")
     void throwJSONException() {
         Assertions.assertThrows(JSONException.class, () -> {
-            GroupDetailData.create(new JSONObject());
+            GroupDetailData.create(JSONObject.parseObject("["));
         });
     }
 

--- a/src/test/java/io/everitoken/sdk/java/dto/PermissionTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/PermissionTest.java
@@ -1,8 +1,8 @@
 package io.everitoken.sdk.java.dto;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 
-import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +15,7 @@ class PermissionTest {
     @DisplayName("Deserialize successful")
     void deserialize() {
         Assertions.assertDoesNotThrow(() -> {
-            Permission permission = Permission.ofRaw(new JSONObject(raw));
+            Permission permission = Permission.ofRaw(JSONObject.parseObject(raw));
             Assertions.assertEquals(raw, JSON.toJSONString(permission));
             Assertions.assertEquals("issue", permission.getName());
             Assertions.assertEquals(1, permission.getThreshold());

--- a/src/test/java/io/everitoken/sdk/java/dto/TokenDetailDataTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/TokenDetailDataTest.java
@@ -2,9 +2,9 @@ package io.everitoken.sdk.java.dto;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,9 +17,9 @@ class TokenDetailDataTest {
         JSONObject raw = new JSONObject();
         raw.put("name", "testTokenName");
         raw.put("domain", "testDomainName");
-        raw.put("metas", new JSONArray(new String[] {}));
-        raw.put("owner", new JSONArray(
-                new String[] { "INVALID_EVT_PUBLIC_KEY", "EVT76uLwUD5t6fkob9Rbc9UxHgdTVshNceyv2hmppw4d82j2zYRpa" }));
+        raw.put("metas", new JSONArray());
+        raw.put("owner", JSONArray
+                .parseArray("[\"INVALID_EVT_PUBLIC_KEY\", \"EVT76uLwUD5t6fkob9Rbc9UxHgdTVshNceyv2hmppw4d82j2zYRpa\"]"));
 
         TokenDetailData tokenDetailData = TokenDetailData.create(raw);
 
@@ -29,6 +29,6 @@ class TokenDetailDataTest {
     @Test
     @DisplayName("Throw exception if valid is not valid")
     void throwExceptionIfJSONIsNotValid() {
-        Assertions.assertThrows(JSONException.class, () -> TokenDetailData.create(new JSONObject()));
+        Assertions.assertThrows(NullPointerException.class, () -> TokenDetailData.create(new JSONObject()));
     }
 }

--- a/src/test/java/io/everitoken/sdk/java/dto/TransactionDataTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/TransactionDataTest.java
@@ -1,6 +1,7 @@
 package io.everitoken.sdk.java.dto;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ class TransactionDataTest {
 
     @Test
     void createObj() {
-        JSONObject raw = new JSONObject(sampleRes);
+        JSONObject raw = JSONObject.parseObject(sampleRes);
         Assertions.assertDoesNotThrow(() -> {
             TransactionData transactionData = TransactionData.ofRaw(raw);
             Assertions.assertEquals(transactionData.getTrxId(), transactionData.getProcessed().getString("id"));

--- a/src/test/java/io/everitoken/sdk/java/dto/TransactionDetailTest.java
+++ b/src/test/java/io/everitoken/sdk/java/dto/TransactionDetailTest.java
@@ -1,8 +1,8 @@
 package io.everitoken.sdk.java.dto;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +18,8 @@ class TransactionDetailTest {
             obj.put("packed_trx", "test_packed_trx");
             obj.put("id", "test_id");
             obj.put("compression", "test_compression");
-            obj.put("signatures", new JSONArray(new String[] {
-                    "SIG_K1_Ke1xR6s7BfUFguPDNbGvH5SnWeKSZnXwepzWK1mWSyVaYkZ8zRDzZkmTNbaGUhwATt1VNV4kDatmvK96uahTsH3cQcKgqJ",
-                    "SIG_K1_Kg3UGU7UVDefMVZLnyDuzCEQarZf3vUFgwLzr3Hrovxdom4WWY5WQdinDNc2gVA98Rpf7Yg3ZGCmjNK13jVyFsnLTwWJMb" }));
+            obj.put("signatures", JSONArray.parseArray(
+                    "[\"SIG_K1_Ke1xR6s7BfUFguPDNbGvH5SnWeKSZnXwepzWK1mWSyVaYkZ8zRDzZkmTNbaGUhwATt1VNV4kDatmvK96uahTsH3cQcKgqJ\", \"SIG_K1_Kg3UGU7UVDefMVZLnyDuzCEQarZf3vUFgwLzr3Hrovxdom4WWY5WQdinDNc2gVA98Rpf7Yg3ZGCmjNK13jVyFsnLTwWJMb\"]"));
             obj.put("transaction", new JSONObject());
             obj.put("block_id", "test_block_id");
             TransactionDetail.create(obj);
@@ -30,7 +29,7 @@ class TransactionDetailTest {
     @Test
     @DisplayName("Throw exception when input is not valid json")
     void throwException() {
-        Assertions.assertThrows(JSONException.class, () -> {
+        Assertions.assertThrows(NullPointerException.class, () -> {
             TransactionDetail.create(new JSONObject());
         });
     }

--- a/src/test/java/io/everitoken/sdk/java/param/FungibleActionParamsTest.java
+++ b/src/test/java/io/everitoken/sdk/java/param/FungibleActionParamsTest.java
@@ -10,7 +10,7 @@ class FungibleActionParamsTest {
     @Test
     @DisplayName("Serialization should be correct")
     void asJSONString() {
-        FungibleActionParams params = new FungibleActionParams("address", "testSymbol");
+        FungibleActionParams params = FungibleActionParams.of("address", "testSymbol");
         JSONObject json = JSONObject.parseObject(params.asBody());
 
         Assertions.assertEquals("address", json.getString("addr"));

--- a/src/test/java/io/everitoken/sdk/java/param/FungibleActionParamsTest.java
+++ b/src/test/java/io/everitoken/sdk/java/param/FungibleActionParamsTest.java
@@ -1,6 +1,7 @@
 package io.everitoken.sdk.java.param;
 
-import org.json.JSONObject;
+import com.alibaba.fastjson.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,11 +11,11 @@ class FungibleActionParamsTest {
     @DisplayName("Serialization should be correct")
     void asJSONString() {
         FungibleActionParams params = new FungibleActionParams("address", "testSymbol");
-        JSONObject json = new JSONObject(params.asBody());
+        JSONObject json = JSONObject.parseObject(params.asBody());
 
         Assertions.assertEquals("address", json.getString("addr"));
         Assertions.assertEquals("testSymbol", json.getString("sym_id"));
-        Assertions.assertEquals(0, json.getInt("skip"));
-        Assertions.assertEquals(10, json.getInt("take"));
+        Assertions.assertEquals(0, (int) json.getInteger("skip"));
+        Assertions.assertEquals(10, (int) json.getInteger("take"));
     }
 }


### PR DESCRIPTION
This adaption is for Android. In Android when it comes to `org.json` it always fall back to the one from `framework`. In order to eliminate the side effect, we replace the `org.json` with `fastjson`.

* higher reliability on signature generation